### PR TITLE
[FIX] enable transaction object save and use generate password for test

### DIFF
--- a/ai/tests.py
+++ b/ai/tests.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 from utils.base_test import BaseTestCase
 from ai.models import RecommendationHistory
 from ai.serializers import RecommendationHistorySerializer
-from authentication.models import AppUser
 from event.models import Event
 from task.models import Task
 
@@ -21,8 +20,6 @@ OPEN_AI_MODULE = 'ai.views.OpenAI'
 class AssistantTest(BaseTestCase):
     def setUp(self):
         super().setUp()
-        # self.user = AppUser.objects.create_user(email='email@email.com',username='testuser',password='test')
-        # self.another_user = AppUser.objects.create_user(email = 'anonymous@gmail.com', username='anonymous', password='test')
         self.client = APIClient()
         self.client.force_authenticate(user=self.premium_user)
         self.event_data = {
@@ -109,9 +106,6 @@ class HistoryTest(BaseTestCase):
 
     def setUp(self):
         self.client = APIClient()
-        # self.user = AppUser.objects.create_user(email='email@email.com',username='testuser',password='test')
-        # self.another_user = AppUser.objects.create_user(email = 'anonymous@gmail.com', username='anonymous', password='test')
-        
         self.client.force_authenticate(user=self.premium_user)
         self.event_data = {
             "id": UUID("9fdfb487-5101-4824-8c3b-0775732aacda"),
@@ -151,9 +145,6 @@ class HistoryTest(BaseTestCase):
 class HistoryDetailTest(BaseTestCase):
     def setUp(self):
         self.client = APIClient()
-        # self.user = AppUser.objects.create_user(email='email@email.com',username='testuser',password='test')
-        # self.another_user = AppUser.objects.create_user(email = 'anonymous@gmail.com', username='anonymous', password='test')
-        
         self.client.force_authenticate(user=self.premium_user)
         
         self.recommendation_attributes = {
@@ -182,9 +173,6 @@ class HistoryDetailTest(BaseTestCase):
 class AutofillTest(BaseTestCase):
     def setUp(self):
         self.client = APIClient()
-        # self.user = AppUser.objects.create_user(email='email@email.com',username='testuser',password='test')
-        # self.another_user = AppUser.objects.create_user(email = 'anonymous@gmail.com', username='anonymous', password='test')
-        
         self.client.force_authenticate(user=self.premium_user)
         self.mock_response = {'choices': [{'message': {'content': '{"name": "Class meet", "date" = "26/02/2024", "budget":1000000, "objective" : "Meningkatkan keakraban pertemanan antar kelas", "attendees":400, "theme" : "Valentine", "services" :  ["stand makanan", "sound system", "MC"]}'} }]}
 

--- a/authentication/tests.py
+++ b/authentication/tests.py
@@ -220,7 +220,6 @@ class CreateShortTokenTest(TestCase):
         user2 = AppUser.objects.create_user(email='email2@email.com',username='testuser2',password=password2)
         UserToken.objects.create(user=user2, token='faketoken', shortened_token=short_token)
         res = create_shortened_token(self.user)
-        print(UserToken.objects.all())
         self.assertNotEqual(short_token, res)
 
 class ProfileUpdateTest(TestCase):

--- a/authentication/tests.py
+++ b/authentication/tests.py
@@ -8,6 +8,7 @@ from rest_framework.test import APIClient
 from .tokens import account_token
 from django.core.files.uploadedfile import SimpleUploadedFile
 import os
+from django.contrib.auth.models import BaseUserManager
 
 REGISTER_LINK = reverse('authentication:register')
 LOGIN_LINK = reverse('authentication:login')
@@ -18,11 +19,12 @@ class RegisterTest(TestCase):
 
     def setUp(self):
         self.client = APIClient()
+        self.password = BaseUserManager().make_random_password()
  
     def test_register_valid(self):
         data = {
                 "username":"user1",
-                "password":"pass1",
+                "password":self.password,
                 "email":"email1@email.com"
         }
         response = self.client.post(REGISTER_LINK, json.dumps(data), content_type='application/json')
@@ -32,7 +34,7 @@ class RegisterTest(TestCase):
     def test_email_format_not_valid(self):
         data ={
                 "username":"user1",
-                "password":"pass1",
+                "password":self.password,
                 "email":"emailnotvalid"
         }
         response = self.client.post(REGISTER_LINK, json.dumps(data), content_type='application/json')
@@ -53,7 +55,7 @@ class RegisterTest(TestCase):
     def test_username_is_already_exist(self):
         data = {
                 "username":"user1",
-                "password":"pass1",
+                "password":self.password,
                 "email":"email1@email.com"
         }
         response = self.client.post(REGISTER_LINK, json.dumps(data), content_type='application/json')
@@ -75,10 +77,11 @@ class RegisterTest(TestCase):
 class LoginTest(TestCase):
     def setUp(self):
         self.client = APIClient()
-        self.user = AppUser.objects.create_user(email='email@email.com',username='testuser',password='test')
+        self.password = BaseUserManager().make_random_password()
+        self.user = AppUser.objects.create_user(email='email@email.com',username='testuser',password=self.password)
 
     def test_login_successful(self):
-        data = {'username': 'testuser', 'password': 'test'}
+        data = {'username': 'testuser', 'password': self.password}
         response = self.client.post(LOGIN_LINK, json.dumps(data), content_type='application/json')
         self.assertEqual(response.status_code, 200)
 
@@ -98,7 +101,8 @@ class LoginTest(TestCase):
 class SendVerificationEmailTest(TestCase):
     def setUp(self):
         self.client = APIClient()
-        self.user = AppUser.objects.create_user(email='email@email.com',username='testuser',password='test')
+        self.password = BaseUserManager().make_random_password()
+        self.user = AppUser.objects.create_user(email='email@email.com',username='testuser',password=self.password)
         self.client.force_authenticate(user=self.user)
     
     def tearDown(self):
@@ -138,7 +142,8 @@ class SendVerificationEmailTest(TestCase):
 class SendRecoverPasswordEmailTest(TestCase):
     def setUp(self):
         self.client = APIClient()
-        self.user = AppUser.objects.create_user(email='email@email.com',username='testuser',password='test')
+        self.password = BaseUserManager().make_random_password()
+        self.user = AppUser.objects.create_user(email='email@email.com',username='testuser',password=self.password)
     
     def tearDown(self):
         UserToken.objects.all().delete()
@@ -198,7 +203,8 @@ class SendRecoverPasswordEmailTest(TestCase):
 
 class CreateShortTokenTest(TestCase):
     def setUp(self):
-        self.user = AppUser.objects.create_user(email='email@email.com',username='testuser',password='test')
+        self.password = BaseUserManager().make_random_password()
+        self.user = AppUser.objects.create_user(email='email@email.com',username='testuser',password=self.password)
 
     def tearDown(self):
         UserToken.objects.all().delete()
@@ -210,7 +216,8 @@ class CreateShortTokenTest(TestCase):
     
     def test_create_token_with_same_short_token(self):
         short_token = account_token.make_token(self.user)[-8:]
-        user2 = AppUser.objects.create_user(email='email2@email.com',username='testuser2',password='test2')
+        password2 = BaseUserManager().make_random_password()
+        user2 = AppUser.objects.create_user(email='email2@email.com',username='testuser2',password=password2)
         UserToken.objects.create(user=user2, token='faketoken', shortened_token=short_token)
         res = create_shortened_token(self.user)
         print(UserToken.objects.all())
@@ -219,7 +226,8 @@ class CreateShortTokenTest(TestCase):
 class ProfileUpdateTest(TestCase):
     def setUp(self):
         self.client = APIClient()
-        self.user = AppUser.objects.create_user(email='test@example.com', username='testuser', password='test')
+        self.password = BaseUserManager().make_random_password()
+        self.user = AppUser.objects.create_user(email='test@example.com', username='testuser', password=self.password)
         self.client.force_authenticate(user=self.user)
         self.profile = Profile.objects.create(user=self.user, bio='Old bio')
 

--- a/payment/tests.py
+++ b/payment/tests.py
@@ -7,6 +7,7 @@ from authentication.models import AppUser
 from rest_framework.test import APIClient
 from package.models import Package
 from utils.base_test import BaseTestCase
+from django.contrib.auth.models import BaseUserManager
 
 SNAP_API = 'payment.views.SNAP_API'
 
@@ -132,7 +133,8 @@ class TransactionDetailAPIViewTestCase(BaseTestCase):
 
     def test_get_transaction_detail_unauthorized(self):
         url = reverse('payment:transaction-detail', kwargs={'id': self.transaction.id})
-        other_user = AppUser.objects.create_user(email='otheruser@example.com', username='otheruser', password='testpassword')
+        other_password = BaseUserManager().make_random_password()
+        other_user = AppUser.objects.create_user(email='otheruser@example.com', username='otheruser', password=other_password)
         self.client.force_authenticate(user=other_user)
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/payment/views.py
+++ b/payment/views.py
@@ -57,7 +57,7 @@ class CreatePaymentView(views.APIView):
                 ]
             },
             "callbacks": {
-                "finish": str(os.getenv('REVELIO_FE_BASE_URL'))+'payment/success/'
+                "finish": str(os.getenv('REVELIO_FE_BASE_URL'))+'payment'
             }
         }
         try:
@@ -107,10 +107,15 @@ class CreatePaymentView(views.APIView):
 
                 payment_status = midtrans_transaction.get("transaction_status")
                 transaction_object = get_object_or_404(Transaction, order_id=order_id)
+                print(transaction_object.status)
+                print('payment stats: ',payment_status)
                 if transaction_object.status != payment_status:
                     transaction_object.status = payment_status
+                    if(transaction_object.status=='expire'):
+                        transaction_object.midtrans_url=None
 
                     if(payment_status=="settlement"):
+                        transaction_object.midtrans_url=None
                         start_subscription = timezone.now()
                         duration_days = transaction_object.package.duration
                         end_subscription = start_subscription + timedelta(days=duration_days)
@@ -122,14 +127,13 @@ class CreatePaymentView(views.APIView):
                         )
 
                 if not transaction_object.payment_type:
-                    transaction_object.midtrans_url=None
                     transaction_object.payment_type = midtrans_transaction.get("payment_type")
                     transaction_object.payment_merchant = midtrans_transaction.get("acquirer")
                     transaction_object.checkout_time = datetime.strptime(midtrans_transaction.get("transaction_time"), "%Y-%m-%d %H:%M:%S")
                     transaction_object.expiry_time = datetime.strptime(midtrans_transaction.get("expiry_time"), "%Y-%m-%d %H:%M:%S")
                     transaction_object.midtrans_transaction_id = midtrans_transaction.get("transaction_id")
 
-                    transaction_object.save()
+                transaction_object.save()
 
                 return Response({'message': midtrans_transaction.get("status_message"), 'transaction_detail': TransactionSerializer(transaction_object).data}, status=status.HTTP_200_OK)
         except Exception as e:

--- a/payment/views.py
+++ b/payment/views.py
@@ -74,7 +74,6 @@ class CreatePaymentView(views.APIView):
                 return Response({'message': 'Transaction successful', 'redirect_url': transaction['redirect_url']}, status=status.HTTP_200_OK)
 
         except Exception as e:
-            print(e)
             return Response({'message': 'Transaction failed'}, status=status.HTTP_400_BAD_REQUEST)
 
     @swagger_auto_schema(
@@ -107,8 +106,6 @@ class CreatePaymentView(views.APIView):
 
                 payment_status = midtrans_transaction.get("transaction_status")
                 transaction_object = get_object_or_404(Transaction, order_id=order_id)
-                print(transaction_object.status)
-                print('payment stats: ',payment_status)
                 if transaction_object.status != payment_status:
                     transaction_object.status = payment_status
                     if(transaction_object.status=='expire'):

--- a/revelio/utils.py
+++ b/revelio/utils.py
@@ -1,5 +1,3 @@
-from rest_framework.exceptions import ValidationError
-
 def get_validation_error_detail(e):
     """
     Extract and format the error message from a ValidationError.

--- a/rundown/tests.py
+++ b/rundown/tests.py
@@ -6,6 +6,7 @@ from rest_framework.test import APIClient
 from authentication.models import AppUser
 from .models import Event, Rundown
 import datetime
+from django.contrib.auth.models import BaseUserManager
 from utils.base_test import BaseTestCase
 
 class RundownBaseTestCase(BaseTestCase):
@@ -157,7 +158,8 @@ class GetRundownListTestCase(RundownBaseTestCase):
 
     def test_not_rundown_owner(self):
         self.client = APIClient()
-        self.user = AppUser.objects.create_user(email='invalid@email.com', username='invalid', password='invalid')
+        invalid_owner_password = BaseUserManager().make_random_password()
+        self.user = AppUser.objects.create_user(email='invalid@email.com', username='invalid', password=invalid_owner_password)
         self.client.force_authenticate(user=self.user)
         url = reverse('rundown-list', args=[self.event_id])
         response = self.client.get(url)

--- a/subscription/tests.py
+++ b/subscription/tests.py
@@ -2,18 +2,19 @@ from datetime import timedelta
 from django.utils import timezone
 from django.test import TestCase
 from rest_framework.test import APIClient
-
 from authentication.models import AppUser
 from package.models import Package
 from subscription.models import Subscription
 from django.urls import reverse
+from django.contrib.auth.models import BaseUserManager
 
 
 # Create your tests here.
 class SubscriptionHistoryTestCase(TestCase):
     def setUp(self):
         self.client = APIClient()
-        self.user = AppUser.objects.create_user(email='user@example.com', username='testuser', password='testpassword')
+        self.password = BaseUserManager().make_random_password()
+        self.user = AppUser.objects.create_user(email='user@example.com', username='testuser', password=self.password)
         self.client.force_authenticate(user=self.user)
         
         self.package = Package.objects.create(name='PREMIUM', price=100, duration=30, event_planner=True, event_tracker=True, event_timeline=True, event_rundown=True, ai_assistant=True)
@@ -45,7 +46,8 @@ class SubscriptionHistoryTestCase(TestCase):
 class LatestSubscriptionTestCase(TestCase):
     def setUp(self):
         self.client = APIClient()
-        self.user = AppUser.objects.create_user(email='user@example.com', username='testuser', password='testpassword')
+        self.password = BaseUserManager().make_random_password()
+        self.user = AppUser.objects.create_user(email='user@example.com', username='testuser', password=self.password)
         self.client.force_authenticate(user=self.user)
         
         self.package = Package.objects.create(name='PREMIUM', price=100, duration=30, event_planner=True, event_tracker=True, event_timeline=True, event_rundown=True, ai_assistant=True)

--- a/utils/base_test.py
+++ b/utils/base_test.py
@@ -10,36 +10,30 @@ class BaseTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        free_package = Package.objects.create(
-            name='Free Package',
-            price=0,
-            duration=365,  
+        cls.free_package = cls.create_package('Free Package', 0, 365, ai_assistant=False)
+        cls.premium_package = cls.create_package('Premium Package', 10000, 30, ai_assistant=True)
+
+        cls.free_user = cls.create_user('free@example.com', 'freeuser')
+        cls.premium_user = cls.create_user('premium@example.com', 'premiumuser')
+        cls.another_user = cls.create_user('anonymous@gmail.com', 'anonymous')
+
+        Subscription.objects.create(user=cls.free_user, plan=cls.free_package, end_date=timezone.now() + timedelta(days=365))
+        Subscription.objects.create(user=cls.premium_user, plan=cls.premium_package, end_date=timezone.now() + timedelta(days=30))
+
+    @staticmethod
+    def create_package(name, price, duration, **features):
+        return Package.objects.create(
+            name=name,
+            price=price,
+            duration=duration,
             event_planner=True,
             event_tracker=True,
             event_timeline=True,
             event_rundown=True,
-            ai_assistant=False
+            **features
         )
 
-        premium_package = Package.objects.create(
-            name='Premium Package',
-            price=10000,
-            duration=30,  
-            event_planner=True,
-            event_tracker=True,
-            event_timeline=True,
-            event_rundown=True,
-            ai_assistant=True
-        )
-
-        free_password = BaseUserManager().make_random_password()
-        premium_password = BaseUserManager().make_random_password()
-        anonymous_password = BaseUserManager().make_random_password()
-
-        cls.free_user = AppUser.objects.create_user(email='free@example.com', username='freeuser', password=free_password)
-        cls.premium_user = AppUser.objects.create_user(email='premium@example.com', username='premiumuser', password=premium_password)
-        cls.another_user = AppUser.objects.create_user(email='anonymous@gmail.com', username='anonymous', password=anonymous_password)
-
-        
-        Subscription.objects.create(user=cls.free_user, plan=free_package, end_date=timezone.now() + timedelta(days=365))
-        Subscription.objects.create(user=cls.premium_user, plan=premium_package, end_date=timezone.now() + timedelta(days=30))
+    @staticmethod
+    def create_user(email, username):
+        password = BaseUserManager().make_random_password()
+        return AppUser.objects.create_user(email=email, username=username, password=password)

--- a/utils/base_test.py
+++ b/utils/base_test.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from authentication.models import AppUser
 from subscription.models import Subscription
 from package.models import Package
+from django.contrib.auth.models import BaseUserManager
 
 class BaseTestCase(TestCase):
     @classmethod
@@ -31,9 +32,14 @@ class BaseTestCase(TestCase):
             ai_assistant=True
         )
 
-        cls.free_user = AppUser.objects.create_user(email='free@example.com', username='freeuser', password='test')
-        cls.premium_user = AppUser.objects.create_user(email='premium@example.com', username='premiumuser', password='test')
-        cls.another_user = AppUser.objects.create_user(email = 'anonymous@gmail.com', username='anonymous', password='test')
+        free_password = BaseUserManager().make_random_password()
+        premium_password = BaseUserManager().make_random_password()
+        anonymous_password = BaseUserManager().make_random_password()
+
+        cls.free_user = AppUser.objects.create_user(email='free@example.com', username='freeuser', password=free_password)
+        cls.premium_user = AppUser.objects.create_user(email='premium@example.com', username='premiumuser', password=premium_password)
+        cls.another_user = AppUser.objects.create_user(email='anonymous@gmail.com', username='anonymous', password=anonymous_password)
+
         
         Subscription.objects.create(user=cls.free_user, plan=free_package, end_date=timezone.now() + timedelta(days=365))
         Subscription.objects.create(user=cls.premium_user, plan=premium_package, end_date=timezone.now() + timedelta(days=30))


### PR DESCRIPTION
In this PR, I have added the transaction object save to enable the object to be updated.
also I have used BaseUserManager create random password so that the password is not exposed in the test environments