### PR TITLE
Fix registration flow (2)

### DIFF
--- a/authentication/tests.py
+++ b/authentication/tests.py
@@ -87,7 +87,8 @@ class RegisterTest(TestCase):
 class LoginTest(BaseTestCase):
     
     def test_login_successful(self):
-        data = {'username': 'testuser', 'password': self.password}
+        self.user2 = AppUser.objects.create_user(email='email2@email.com',username='testuser2',password=self.password, is_verified_user=True)
+        data = {'username': 'testuser2', 'password': self.password}
         response = self.client.post(LOGIN_LINK, json.dumps(data), content_type='application/json')
         self.assertEqual(response.status_code, 200)
 
@@ -119,6 +120,8 @@ class SendVerificationEmailTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(mail.outbox), 1) 
         self.assertEqual(mail.outbox[0].to, ['email@email.com'])
+        response = self.client.get(EMAIL_VERIFICATION_LINK)
+        self.assertEqual(response.status_code, 200)
     
     def test_valid_verification_token(self):
         token = account_token.make_token(self.user)
@@ -158,6 +161,8 @@ class SendRecoverPasswordEmailTest(BaseTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(mail.outbox), 1) 
         self.assertEqual(mail.outbox[0].to, ['email@email.com'])
+        response = self.client.post((RECOVER_PASSWORD_LINK), {'email':'email@email.com'})
+        self.assertEqual(response.status_code, 200)
     
     def test_sent_wrong_email_recover_password(self):
         response = self.client.post((RECOVER_PASSWORD_LINK), {'email':'wrong@email.com'})

--- a/authentication/tests.py
+++ b/authentication/tests.py
@@ -96,7 +96,13 @@ class LoginTest(BaseTestCase):
         data = {'username': 'testuser', 'password': 'testwrongpassword'}
         response = self.client.post(LOGIN_LINK, json.dumps(data), content_type='application/json')
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()['msg'],"Wrong username/password!") 
+        self.assertEqual(response.json()['msg'],"Wrong username/password!")
+
+    def test_login_failed_not_verfied(self):
+        data = {'username': 'testuser', 'password': self.password}
+        response = self.client.post(LOGIN_LINK, json.dumps(data), content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['msg'],"You have not verified yet. Please register again and verify your account!") 
 
     def test_missing_fields(self):
         data = {

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -86,8 +86,10 @@ class LoginView(APIView):
             refresh = RefreshToken.for_user(user)
             return Response({'refresh': str(refresh),
                              'access': str(refresh.access_token)})
-        else:
+        elif user is None:
             return Response({'msg': 'Wrong username/password!'}, status=400)
+        else:
+            return Response({'msg': 'You have not verified yet. Please register again and verify your account!'}, status=400)
         
 class SendVerificationEmailView(APIView):
 

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -82,7 +82,7 @@ class LoginView(APIView):
         username = request.data.get('username')
         password = request.data.get('password')
         user = authenticate(request, username=username,password=password)
-        if user is not None:
+        if user is not None and AppUser.objects.get(id=user.pk).is_verified_user:
             refresh = RefreshToken.for_user(user)
             return Response({'refresh': str(refresh),
                              'access': str(refresh.access_token)})
@@ -96,6 +96,10 @@ class SendVerificationEmailView(APIView):
     def get(self, request):
         if request.user.is_verified_user != True:
             user = request.user
+            if UserToken.objects.filter(user=user).exists():
+                token = UserToken.objects.get(user=user).token
+                if account_token.check_token(user, token):
+                    return Response({'msg': 'Token already delivered!'})
             token = create_shortened_token(user)
             asyncio.run(send_verification_email(user, token.upper()))
             return Response({'msg': 'Email delivered!'})
@@ -113,6 +117,7 @@ class SendVerificationEmailView(APIView):
                 if account_token.check_token(user, token):
                     user.is_verified_user = True
                     user.save()
+                    UserToken.objects.filter(user=user).delete()
                     Subscription.objects.create(user=user, plan=Package.objects.get(id=1), start_date=timezone.now(), end_date=timezone.make_aware(datetime(year=9999, month=12, day=31)))
                     return Response({'message': 'Email verified successfully!'}, status=200)
                 else:
@@ -145,6 +150,10 @@ class SendRecoverPasswordEmailView(APIView):
         is_user_exist = AppUser.objects.filter(email=email).exists()
         if is_user_exist:
             user = AppUser.objects.get(email=email)
+            if UserToken.objects.filter(user=user).exists():
+                token = UserToken.objects.get(user=user).token
+                if account_token.check_token(user, token):
+                    return Response({'msg': 'Token already delivered!'})
             token = create_shortened_token(user).upper()
             asyncio.run(send_recover_account_email(user, token))
             return Response({'msg': 'Email delivered!'})

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -174,6 +174,7 @@ class SendRecoverPasswordEmailView(APIView):
                 if account_token.check_token(user, token):
                     user.set_password(new_password)
                     user.save()
+                    UserToken.objects.filter(user=user).delete()
                     return Response({'msg': 'Password changes successfully!'}, status=200)
                 else:
                     return Response({'msg': 'Expired token!'}, status=400)

--- a/revelio/settings.py
+++ b/revelio/settings.py
@@ -185,7 +185,7 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL')
 
-PASSWORD_RESET_TIMEOUT = 300
+PASSWORD_RESET_TIMEOUT = 1500
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/

--- a/revelio/settings_dev.py
+++ b/revelio/settings_dev.py
@@ -179,7 +179,7 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL')
 
-PASSWORD_RESET_TIMEOUT = 300
+PASSWORD_RESET_TIMEOUT = 1500
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/


### PR DESCRIPTION
What fixed:
-) Restrict so that only verified user can logged in.
-) Fix so system won't sent another email when there's still active token.
-) Changes token time limit to 25 minutes.
-) Make sure that every token can only be used once (delete the token every time user use it to verify their email or recover password).