### PR TITLE
Fix registration flow (2) (#75)

### DIFF
--- a/authentication/tests.py
+++ b/authentication/tests.py
@@ -87,7 +87,8 @@ class RegisterTest(TestCase):
 class LoginTest(BaseTestCase):
     
     def test_login_successful(self):
-        data = {'username': 'testuser', 'password': self.password}
+        self.user2 = AppUser.objects.create_user(email='email2@email.com',username='testuser2',password=self.password, is_verified_user=True)
+        data = {'username': 'testuser2', 'password': self.password}
         response = self.client.post(LOGIN_LINK, json.dumps(data), content_type='application/json')
         self.assertEqual(response.status_code, 200)
 
@@ -95,7 +96,13 @@ class LoginTest(BaseTestCase):
         data = {'username': 'testuser', 'password': 'testwrongpassword'}
         response = self.client.post(LOGIN_LINK, json.dumps(data), content_type='application/json')
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()['msg'],"Wrong username/password!") 
+        self.assertEqual(response.json()['msg'],"Wrong username/password!")
+
+    def test_login_failed_not_verfied(self):
+        data = {'username': 'testuser', 'password': self.password}
+        response = self.client.post(LOGIN_LINK, json.dumps(data), content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['msg'],"You have not verified yet. Please register again and verify your account!") 
 
     def test_missing_fields(self):
         data = {
@@ -119,6 +126,8 @@ class SendVerificationEmailTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(mail.outbox), 1) 
         self.assertEqual(mail.outbox[0].to, ['email@email.com'])
+        response = self.client.get(EMAIL_VERIFICATION_LINK)
+        self.assertEqual(response.status_code, 200)
     
     def test_valid_verification_token(self):
         token = account_token.make_token(self.user)
@@ -158,6 +167,8 @@ class SendRecoverPasswordEmailTest(BaseTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(mail.outbox), 1) 
         self.assertEqual(mail.outbox[0].to, ['email@email.com'])
+        response = self.client.post((RECOVER_PASSWORD_LINK), {'email':'email@email.com'})
+        self.assertEqual(response.status_code, 200)
     
     def test_sent_wrong_email_recover_password(self):
         response = self.client.post((RECOVER_PASSWORD_LINK), {'email':'wrong@email.com'})

--- a/revelio/settings.py
+++ b/revelio/settings.py
@@ -185,7 +185,7 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL')
 
-PASSWORD_RESET_TIMEOUT = 300
+PASSWORD_RESET_TIMEOUT = 1500
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/

--- a/revelio/settings_dev.py
+++ b/revelio/settings_dev.py
@@ -179,7 +179,7 @@ EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL')
 
-PASSWORD_RESET_TIMEOUT = 300
+PASSWORD_RESET_TIMEOUT = 1500
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/


### PR DESCRIPTION
What fixed:
-) Restrict so that only verified user can logged in. 
-) Fix so system won't sent another email when there's still active token.
-) Changes token time limit to 25 minutes.
-) Make sure that every token can only be used once (delete the token every time user use it to verify their email or recover password).